### PR TITLE
Add RFC 7830 padding to DNS requests

### DIFF
--- a/dns/cmd/main.go
+++ b/dns/cmd/main.go
@@ -39,6 +39,7 @@ func main() {
 			Class: 1,
 		}},
 	}
+	qq.AddPadding()
 	result, err := dns.DoH(context.Background(), qq, url)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "dns.DoH: %v", err)

--- a/dns/message.go
+++ b/dns/message.go
@@ -50,7 +50,6 @@ var (
 		"NSEC3":      50,    // RFC 5155
 		"NSEC3PARAM": 51,    // RFC 5155
 		"OPENPGPKEY": 61,    // RFC 7929
-		"OPT":        41,    // RFC 6891
 		"PTR":        12,    // RFC 1035
 		"RP":         17,    // RFC 1183
 		"RRSIG":      46,    // RFC 4034
@@ -156,7 +155,7 @@ type DNSKEY struct {
 	PublicKey []byte `json:"publickey"`
 }
 
-// Option represents a OPT pseudo Resource Record.
+// Option represents a OPT pseudo Resource Record option.
 type Option struct {
 	Code uint16 `json:"code"`
 	Data []byte `json:"data"`
@@ -256,6 +255,8 @@ func (m *Message) AddPadding() {
 	opts = slices.DeleteFunc(opts, func(opt Option) bool {
 		return opt.Code == 12 // Padding
 	})
+	m.Additional[p].Data = opts
+
 	padSize := (128 - (len(m.Bytes())+4)%128) % 128
 	opts = append(opts, Option{
 		Code: 12, // Padding

--- a/dns/message.go
+++ b/dns/message.go
@@ -240,7 +240,7 @@ type URI struct {
 
 // ResponseCode returns the Extended RCODE.
 func (m Message) ResponseCode() uint16 {
-	rc := uint16(m.RCode)
+	rc := uint16(m.RCode & 0x0f)
 	if p := slices.IndexFunc(m.Additional, func(rr RR) bool {
 		return rr.Type == 41 // OPT
 	}); p >= 0 {
@@ -257,12 +257,12 @@ func (m *Message) AddPadding() {
 		return rr.Type == 41 // OPT
 	})
 	if p < 0 {
+		p = len(m.Additional)
 		m.Additional = append(m.Additional, RR{
 			Type:  41,   // OPT
 			Class: 4096, // Max payload size
 			Data:  []Option{},
 		})
-		p = len(m.Additional) - 1
 	}
 	opts := m.Additional[p].Data.([]Option)
 	opts = slices.DeleteFunc(opts, func(opt Option) bool {

--- a/dns/message_test.go
+++ b/dns/message_test.go
@@ -511,3 +511,24 @@ func TestMessageNXDomain(t *testing.T) {
 		t.Errorf("Got %#v, want %#v", got, want)
 	}
 }
+
+func TestPadding(t *testing.T) {
+	m := Message{
+		RD: 1,
+		Question: []Question{{
+			Name:  "foo.example.com",
+			Type:  0x1,
+			Class: 0x1,
+		}},
+	}
+	m.AddPadding()
+	b := m.Bytes()
+	if n := len(b) % 128; n != 0 {
+		t.Errorf("n%%128 = %d, want 0", n)
+	}
+	m2, err := DecodeMessage(b)
+	if err != nil {
+		t.Fatalf("DecodeMessage: %v", err)
+	}
+	t.Logf("m2: %#v", m2)
+}

--- a/dns/message_test.go
+++ b/dns/message_test.go
@@ -552,3 +552,19 @@ func TestPadding(t *testing.T) {
 		t.Run(fmt.Sprintf("NoPadding-%d", i), run)
 	}
 }
+
+func TestResponseCode(t *testing.T) {
+	m := Message{
+		RCode: 1,
+	}
+	if got, want := m.ResponseCode(), uint16(1); got != want {
+		t.Errorf("ResponseCode() = %d, want %d", got, want)
+	}
+	m.Additional = []RR{{
+		Type: 41,
+		TTL:  0x01ffffff,
+	}}
+	if got, want := m.ResponseCode(), uint16(17); got != want {
+		t.Errorf("ResponseCode() = %d, want %d", got, want)
+	}
+}

--- a/resolve.go
+++ b/resolve.go
@@ -24,7 +24,7 @@ var (
 	ErrNotImplemented    = errors.New("not implemented")
 	ErrQueryRefused      = errors.New("query refused")
 
-	rcode = map[uint8]error{
+	rcode = map[uint16]error{
 		1: ErrFormatError,
 		2: ErrServerFailure,
 		3: ErrNonExistentDomain,
@@ -314,7 +314,7 @@ func (r *Resolver) resolveOne(ctx context.Context, name, typ string) ([]any, err
 		return nil, err
 	}
 
-	if rc := result.RCode; rc != 0 {
+	if rc := result.ResponseCode(); rc != 0 {
 		if err := rcode[rc]; err != nil {
 			return nil, fmt.Errorf("%s (%s): %w (%d)", name, typ, rcode[rc], rc)
 		}

--- a/resolve.go
+++ b/resolve.go
@@ -307,6 +307,7 @@ func (r *Resolver) resolveOne(ctx context.Context, name, typ string) ([]any, err
 			Class: 1,
 		}},
 	}
+	qq.AddPadding()
 
 	result, err := dns.DoH(ctx, qq, r.baseURL.String())
 	if err != nil {


### PR DESCRIPTION
Add `Message.AddPadding()` which automatically adds padding to the DNS message. The padding size is calculated to make the total size of each message a multiple of 128 as recommended in RFC 8467.

This change also adds partial support for RFC 6891 - Extension Mechanisms for DNS (EDNS(0)). In particular, when padding is used, servers may return extended response codes. This change also adds `Message.ResponseCode()` , which returns the rcode or extended rcode automatically.