### PR TITLE
Allow comma-separated list of addresses in Dial

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -6,8 +6,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
+	"iter"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -18,6 +20,9 @@ import (
 //
 // If the name resolution returns multiple IP addresses, Dial iterates over them
 // until a connection is successfully established.
+//
+// Multiple comma-separated addresses may be provided. Dial attempts to connect
+// to them in the order they are listed.
 //
 // Dial is equivalent to:
 //
@@ -99,6 +104,9 @@ type Dialer[T any] struct {
 //
 // If the name resolution returns multiple IP addresses, Dial iterates over them
 // until a connection is successfully established. See [Dialer] for finer control.
+//
+// Multiple comma-separated addresses may be provided. Dial attempts to connect
+// to them in the order they are listed.
 func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Config) (T, error) {
 	var nilConn T
 	if d.DialFunc == nil {
@@ -109,27 +117,49 @@ func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Conf
 	} else {
 		tc = tc.Clone()
 	}
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
-		port = "443"
-	}
 	resolver := d.Resolver
 	if resolver == nil {
 		resolver = DefaultResolver
 	}
-	result, err := resolver.Resolve(ctx, host)
-	if err != nil {
-		return nilConn, err
+	type dialTarget struct {
+		host          string
+		resolveTarget Target
+		err           error
 	}
-	iport, err := strconv.Atoi(port)
-	if err != nil {
-		return nilConn, err
-	}
-	if tc.ServerName == "" {
-		tc.ServerName = host
-	}
-	targetChan := make(chan Target)
+	targetIterator := iter.Seq[dialTarget](func(yield func(dialTarget) bool) {
+		for _, a := range strings.Split(addr, ",") {
+			a := strings.TrimSpace(a)
+			host, port, err := net.SplitHostPort(a)
+			if err != nil {
+				host = a
+				port = "443"
+			}
+			result, err := resolver.Resolve(ctx, host)
+			if err != nil {
+				if !yield(dialTarget{err: err}) {
+					return
+				}
+				continue
+			}
+			iport, err := strconv.Atoi(port)
+			if err != nil {
+				if !yield(dialTarget{err: err}) {
+					return
+				}
+				continue
+			}
+			for target := range result.Targets(network, iport) {
+				if !yield(dialTarget{
+					host:          host,
+					resolveTarget: target,
+				}) {
+					return
+				}
+			}
+		}
+	})
+
+	targetChan := make(chan dialTarget)
 	connChan := make(chan T)
 	errChan := make(chan error)
 	wakeChan := make(chan struct{})
@@ -194,16 +224,23 @@ func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Conf
 		go func() {
 			defer wg.Done()
 			for target := range targetChan {
+				if target.err != nil {
+					sendErr(target.err)
+					continue
+				}
 				tc := tc.Clone()
-				if needECH && target.ECH != nil {
-					tc.EncryptedClientHelloConfigList = target.ECH
+				if tc.ServerName == "" {
+					tc.ServerName = target.host
+				}
+				if needECH && target.resolveTarget.ECH != nil {
+					tc.EncryptedClientHelloConfigList = target.resolveTarget.ECH
 				}
 				if d.RequireECH && tc.EncryptedClientHelloConfigList == nil {
 					sendErr(errors.New("unable to get ECH config list"))
 					continue
 				}
 				ctx, cancel := context.WithTimeout(ctx, timeout)
-				conn, err := d.dialOne(ctx, network, target.Address.String(), tc)
+				conn, err := d.dialOne(ctx, network, target.resolveTarget.Address.String(), tc)
 				cancel()
 				if err != nil {
 					sendErr(err)
@@ -221,7 +258,7 @@ func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Conf
 
 	go func() {
 		first := true
-		for target := range result.Targets(network, iport) {
+		for target := range targetIterator {
 			if !first {
 				select {
 				case <-ctx.Done():

--- a/dial_test.go
+++ b/dial_test.go
@@ -239,17 +239,7 @@ func TestDialer(t *testing.T) {
 	t.Run("MultipleTargetsMultipleAddressesWithPublicName", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com:8443,h2.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
-			pseudo-error "1.0.0.1:1000" ECH OK
-			pseudo-error "1.0.0.2:1000" ECH OK
-			pseudo-error "1.0.0.3:1000" ECH OK
-			pseudo-error "1.0.0.4:1000" ECH OK
-			pseudo-error "1.0.0.5:1000" ECH OK
 			pseudo-error "3.0.0.1:1000" ECH OK
-			pseudo-error "2.0.0.1:2000" ECH publicname:example.com
-			pseudo-error "2.0.0.2:2000" ECH publicname:example.com
-			pseudo-error "2.0.0.3:2000" ECH publicname:example.com
-			pseudo-error "2.0.0.4:2000" ECH publicname:example.com
-			pseudo-error "2.0.0.5:2000" ECH publicname:example.com
 			pseudo-error "3.0.0.1:2000" ECH publicname:example.com
 			pseudo-error "3.0.0.1:8443" ECH publicname:example.com
 			pseudo-error "4.0.0.1:443" ECH publicname:example.com`, "\t", ""))

--- a/dial_test.go
+++ b/dial_test.go
@@ -246,6 +246,28 @@ func TestDialer(t *testing.T) {
 		}
 	})
 
+	t.Run("MultipleTargetsMultipleAddressesWithPublicName", func(t *testing.T) {
+		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com:8443,h2.example.com", nil)
+		want := strings.TrimSpace(strings.ReplaceAll(`
+			pseudo-error "1.0.0.1:1000" ECH OK
+			pseudo-error "1.0.0.2:1000" ECH OK
+			pseudo-error "1.0.0.3:1000" ECH OK
+			pseudo-error "1.0.0.4:1000" ECH OK
+			pseudo-error "1.0.0.5:1000" ECH OK
+			pseudo-error "3.0.0.1:1000" ECH OK
+			pseudo-error "2.0.0.1:2000" ECH publicname:example.com
+			pseudo-error "2.0.0.2:2000" ECH publicname:example.com
+			pseudo-error "2.0.0.3:2000" ECH publicname:example.com
+			pseudo-error "2.0.0.4:2000" ECH publicname:example.com
+			pseudo-error "2.0.0.5:2000" ECH publicname:example.com
+			pseudo-error "3.0.0.1:2000" ECH publicname:example.com
+			pseudo-error "3.0.0.1:8443" ECH publicname:example.com
+			pseudo-error "4.0.0.1:443" ECH publicname:example.com`, "\t", ""))
+		if got.Error() != want {
+			t.Errorf("Got %q, want %q", got, want)
+		}
+	})
+
 	dialer.PublicName = ""
 	t.Run("MultipleTargetsNoPublicName", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com:8443", nil)

--- a/examples_test.go
+++ b/examples_test.go
@@ -36,6 +36,19 @@ func ExampleDial() {
 	fmt.Fprintln(conn, "Hello!")
 }
 
+func ExampleDial_multiple() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "tcp", "private1.example.com,private2.example.com", &tls.Config{})
+	if err != nil {
+		log.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintln(conn, "Hello!")
+}
+
 func ExampleNewConn() {
 	ctx := context.Background()
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -49,6 +49,19 @@ func ExampleDial_multiple() {
 	fmt.Fprintln(conn, "Hello!")
 }
 
+func ExampleDial_multiple_ip_addresses() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "tcp", "192.168.0.1,192.168.0.2,192.168.0.3", &tls.Config{})
+	if err != nil {
+		log.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintln(conn, "Hello!")
+}
+
 func ExampleNewConn() {
 	ctx := context.Background()
 


### PR DESCRIPTION
The `addr` argument to `Dial` is now a comma-separated list of addresses.

The existing behavior hasn't changed. `Dial` resolves the first address and attempts to connect to each resolved target until it connects successfully. If `Dial` runs out of targets to try, it moves on to the next address, etc.