### PR TITLE
Allow non-default schemes and ports

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -140,7 +140,7 @@ func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Conf
 				}
 				continue
 			}
-			for target := range result.Targets(network, 0) {
+			for target := range result.Targets(network) {
 				if !yield(dialTarget{
 					host:     host,
 					resolved: target,

--- a/dial.go
+++ b/dial.go
@@ -5,10 +5,10 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"io"
 	"iter"
 	"net"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -129,26 +129,18 @@ func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Conf
 	targets := iter.Seq[dialTarget](func(yield func(dialTarget) bool) {
 		for _, a := range strings.Split(addr, ",") {
 			a := strings.TrimSpace(a)
-			host, port, err := net.SplitHostPort(a)
+			host, _, err := net.SplitHostPort(a)
 			if err != nil {
 				host = a
-				port = "0"
 			}
-			result, err := resolver.Resolve(ctx, host)
+			result, err := resolver.Resolve(ctx, a)
 			if err != nil {
-				if !yield(dialTarget{err: err}) {
+				if !yield(dialTarget{err: fmt.Errorf("%s: %w", a, err)}) {
 					return
 				}
 				continue
 			}
-			iport, err := strconv.Atoi(port)
-			if err != nil {
-				if !yield(dialTarget{err: err}) {
-					return
-				}
-				continue
-			}
-			for target := range result.Targets(network, iport) {
+			for target := range result.Targets(network, 0) {
 				if !yield(dialTarget{
 					host:     host,
 					resolved: target,
@@ -236,14 +228,14 @@ func (d *Dialer[T]) Dial(ctx context.Context, network, addr string, tc *tls.Conf
 					tc.EncryptedClientHelloConfigList = target.resolved.ECH
 				}
 				if d.RequireECH && tc.EncryptedClientHelloConfigList == nil {
-					sendErr(errors.New("unable to get ECH config list"))
+					sendErr(fmt.Errorf("%s: unable to get ECH config list", target.host))
 					continue
 				}
 				ctx, cancel := context.WithTimeout(ctx, timeout)
 				conn, err := d.dialOne(ctx, network, target.resolved.Address.String(), tc)
 				cancel()
 				if err != nil {
-					sendErr(err)
+					sendErr(fmt.Errorf("%s: %w", target.host, err))
 					continue
 				}
 				sendConn(conn)

--- a/dial_test.go
+++ b/dial_test.go
@@ -220,8 +220,7 @@ func TestDialer(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
 			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
-			h1.example.com: pseudo-error "3.0.0.1:2000" ECH publicname:example.com
-			h1.example.com: pseudo-error "3.0.0.1:443" ECH publicname:example.com`, "\t", ""))
+			h1.example.com: pseudo-error "3.0.0.1:2000" ECH publicname:example.com`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -241,7 +240,6 @@ func TestDialer(t *testing.T) {
 		want := strings.TrimSpace(strings.ReplaceAll(`
 			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
 			h1.example.com: pseudo-error "3.0.0.1:2000" ECH publicname:example.com
-			h1.example.com: pseudo-error "3.0.0.1:443" ECH publicname:example.com
 			h2.example.com: pseudo-error "4.0.0.1:8443" ECH publicname:example.com`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
@@ -253,8 +251,7 @@ func TestDialer(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
 			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
-			h1.example.com: pseudo-error "3.0.0.1:2000" ECH nil
-			h1.example.com: pseudo-error "3.0.0.1:443" ECH nil`, "\t", ""))
+			h1.example.com: pseudo-error "3.0.0.1:2000" ECH nil`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -265,7 +262,6 @@ func TestDialer(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
 			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
-			h1.example.com: unable to get ECH config list
 			h1.example.com: unable to get ECH config list`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)

--- a/dial_test.go
+++ b/dial_test.go
@@ -219,9 +219,9 @@ func TestDialer(t *testing.T) {
 	t.Run("MultipleTargetsWithPublicName", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
-			pseudo-error "3.0.0.1:1000" ECH OK
-			pseudo-error "3.0.0.1:2000" ECH publicname:example.com
-			pseudo-error "3.0.0.1:443" ECH publicname:example.com`, "\t", ""))
+			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
+			h1.example.com: pseudo-error "3.0.0.1:2000" ECH publicname:example.com
+			h1.example.com: pseudo-error "3.0.0.1:443" ECH publicname:example.com`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -230,7 +230,7 @@ func TestDialer(t *testing.T) {
 	t.Run("OneTargetNoECHWithPublicName", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h2.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
-			pseudo-error "4.0.0.1:443" ECH publicname:example.com`, "\t", ""))
+			h2.example.com: pseudo-error "4.0.0.1:443" ECH publicname:example.com`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -239,10 +239,10 @@ func TestDialer(t *testing.T) {
 	t.Run("MultipleTargetsMultipleAddressesWithPublicName", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com,h2.example.com:8443", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
-			pseudo-error "3.0.0.1:1000" ECH OK
-			pseudo-error "3.0.0.1:2000" ECH publicname:example.com
-			pseudo-error "3.0.0.1:443" ECH publicname:example.com
-			pseudo-error "4.0.0.1:8443" ECH publicname:example.com`, "\t", ""))
+			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
+			h1.example.com: pseudo-error "3.0.0.1:2000" ECH publicname:example.com
+			h1.example.com: pseudo-error "3.0.0.1:443" ECH publicname:example.com
+			h2.example.com: pseudo-error "4.0.0.1:8443" ECH publicname:example.com`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -252,9 +252,9 @@ func TestDialer(t *testing.T) {
 	t.Run("MultipleTargetsNoPublicName", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
-			pseudo-error "3.0.0.1:1000" ECH OK
-			pseudo-error "3.0.0.1:2000" ECH nil
-			pseudo-error "3.0.0.1:443" ECH nil`, "\t", ""))
+			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
+			h1.example.com: pseudo-error "3.0.0.1:2000" ECH nil
+			h1.example.com: pseudo-error "3.0.0.1:443" ECH nil`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -264,9 +264,9 @@ func TestDialer(t *testing.T) {
 	t.Run("MultipleTargetsNoPublicNameRequireECH", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h1.example.com", nil)
 		want := strings.TrimSpace(strings.ReplaceAll(`
-			pseudo-error "3.0.0.1:1000" ECH OK
-			unable to get ECH config list
-			unable to get ECH config list`, "\t", ""))
+			h1.example.com: pseudo-error "3.0.0.1:1000" ECH OK
+			h1.example.com: unable to get ECH config list
+			h1.example.com: unable to get ECH config list`, "\t", ""))
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}
@@ -274,7 +274,7 @@ func TestDialer(t *testing.T) {
 
 	t.Run("OneTargetNoECHNoPublicNameRequireECH", func(t *testing.T) {
 		_, got := dialer.Dial(t.Context(), "tcp", "h2.example.com", nil)
-		want := "unable to get ECH config list"
+		want := "h2.example.com: unable to get ECH config list"
 		if got.Error() != want {
 			t.Errorf("Got %q, want %q", got, want)
 		}

--- a/example/resolve/main.go
+++ b/example/resolve/main.go
@@ -48,7 +48,7 @@ func main() {
 		fmt.Printf("HTTPS: %s\n", h)
 	}
 	first := true
-	for a := range result.Targets("tcp", 0) {
+	for a := range result.Targets("tcp") {
 		if first {
 			first = false
 			fmt.Println("\nOrdered Targets:")

--- a/examples_test.go
+++ b/examples_test.go
@@ -62,6 +62,32 @@ func ExampleDial_multiple_ip_addresses() {
 	fmt.Fprintln(conn, "Hello!")
 }
 
+func ExampleDial_with_ports() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "tcp", "private1.example.com:8443,private2.example.com:10443,192.168.0.3", &tls.Config{})
+	if err != nil {
+		log.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintln(conn, "Hello!")
+}
+
+func ExampleDial_uri() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := Dial(ctx, "tcp", "https://private.example.com:8443", &tls.Config{})
+	if err != nil {
+		log.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintln(conn, "Hello!")
+}
+
 func ExampleNewConn() {
 	ctx := context.Background()
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -129,7 +129,35 @@ func ExampleResolve() {
 		log.Fatalf("Resolve: %v", err)
 	}
 
-	for target := range result.Targets("tcp", 443) {
+	for target := range result.Targets("tcp") {
+		fmt.Printf("Address: %s  ECH: %s\n", target.Address, base64.StdEncoding.EncodeToString(target.ECH))
+	}
+}
+
+func ExampleResolve_with_port() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := Resolve(ctx, "private.example.com:8443")
+	if err != nil {
+		log.Fatalf("Resolve: %v", err)
+	}
+
+	for target := range result.Targets("tcp") {
+		fmt.Printf("Address: %s  ECH: %s\n", target.Address, base64.StdEncoding.EncodeToString(target.ECH))
+	}
+}
+
+func ExampleResolve_with_uri() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := Resolve(ctx, "https://private.example.com:8443")
+	if err != nil {
+		log.Fatalf("Resolve: %v", err)
+	}
+
+	for target := range result.Targets("tcp") {
 		fmt.Printf("Address: %s  ECH: %s\n", target.Address, base64.StdEncoding.EncodeToString(target.ECH))
 	}
 }

--- a/examples_test.go
+++ b/examples_test.go
@@ -146,11 +146,11 @@ func ExampleNewDialer() {
 	fmt.Fprintln(conn, "Hello!")
 }
 
-func ExampleResolve() {
+func ExampleResolver_Resolve() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	result, err := Resolve(ctx, "private.example.com")
+	result, err := DefaultResolver.Resolve(ctx, "private.example.com")
 	if err != nil {
 		log.Fatalf("Resolve: %v", err)
 	}
@@ -160,11 +160,11 @@ func ExampleResolve() {
 	}
 }
 
-func ExampleResolve_with_port() {
+func ExampleResolver_Resolve_with_port() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	result, err := Resolve(ctx, "private.example.com:8443")
+	result, err := DefaultResolver.Resolve(ctx, "private.example.com:8443")
 	if err != nil {
 		log.Fatalf("Resolve: %v", err)
 	}
@@ -174,11 +174,11 @@ func ExampleResolve_with_port() {
 	}
 }
 
-func ExampleResolve_with_uri() {
+func ExampleResolver_Resolve_with_uri() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	result, err := Resolve(ctx, "https://private.example.com:8443")
+	result, err := DefaultResolver.Resolve(ctx, "https://private.example.com:8443")
 	if err != nil {
 		log.Fatalf("Resolve: %v", err)
 	}

--- a/resolve.go
+++ b/resolve.go
@@ -92,6 +92,7 @@ func (r ResolveResult) Targets(network string, port int) iter.Seq[Target] {
 			return yield(Target{Address: addr, ECH: ech})
 		}
 
+		var count int
 		for _, h := range r.HTTPS {
 			httpsPort := port
 			if httpsPort == 0 && h.Port > 0 {
@@ -102,6 +103,7 @@ func (r ResolveResult) Targets(network string, port int) iter.Seq[Target] {
 					if !add(a, httpsPort, h.ECH) {
 						return
 					}
+					count++
 				}
 				continue
 			}
@@ -109,19 +111,25 @@ func (r ResolveResult) Targets(network string, port int) iter.Seq[Target] {
 				if !add(a, httpsPort, h.ECH) {
 					return
 				}
+				count++
 			}
 			if len(r.Address) == 0 {
 				for _, a := range h.IPv4Hint {
 					if !add(a, httpsPort, h.ECH) {
 						return
 					}
+					count++
 				}
 				for _, a := range h.IPv6Hint {
 					if !add(a, httpsPort, h.ECH) {
 						return
 					}
+					count++
 				}
 			}
+		}
+		if count > 0 {
+			return
 		}
 		for _, a := range r.Address {
 			if !add(a, port, nil) {

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -319,7 +319,7 @@ func TestResolveResultTargets(t *testing.T) {
 		},
 	} {
 		var s []string
-		for target := range tc.result.Targets("tcp", 0) {
+		for target := range tc.result.Targets("tcp") {
 			v := target.Address.String()
 			if len(target.ECH) > 0 {
 				v += " " + string(target.ECH)

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -80,24 +80,28 @@ func TestResolve(t *testing.T) {
 		{
 			name: "www.example.com",
 			want: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 3}},
 			},
 		},
 		{
 			name: "example.com",
 			want: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 3}},
 			},
 		},
 		{
 			name: "www2.example.com",
 			want: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 3}},
 			},
 		},
 		{
 			name: "foo.example.com",
 			want: ResolveResult{
+				Port: 443,
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, ALPN: []string{"h2"}, Port: 8443, IPv4Hint: []net.IP{{127, 0, 0, 1}},
 				}},
@@ -106,6 +110,7 @@ func TestResolve(t *testing.T) {
 		{
 			name: "bar.example.com",
 			want: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 4}},
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, ALPN: []string{"h2"}, ECH: []byte{0, 1, 2},
@@ -115,6 +120,7 @@ func TestResolve(t *testing.T) {
 		{
 			name: "xxx.example.com",
 			want: ResolveResult{
+				Port: 443,
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, Target: "example.com", ALPN: []string{"h2"}, ECH: []byte{0, 1, 2},
 				}},
@@ -126,6 +132,7 @@ func TestResolve(t *testing.T) {
 		{
 			name: "yyy.example.com",
 			want: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 5}},
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, Target: "example.com", ALPN: []string{"h2"}, ECH: []byte{0, 1, 2},
@@ -217,24 +224,28 @@ func TestResolveResultTargets(t *testing.T) {
 	}{
 		{
 			result: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 1}},
 			},
 			want: "192.168.0.1:443",
 		},
 		{
 			result: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 1}, {192, 168, 0, 2}},
 			},
 			want: "192.168.0.1:443 | 192.168.0.2:443",
 		},
 		{
 			result: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 1}, {192, 168, 0, 2}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
 			},
 			want: "192.168.0.1:443 | 192.168.0.2:443 | [::1]:443",
 		},
 		{
 			result: ResolveResult{
+				Port:    443,
 				Address: []net.IP{{192, 168, 0, 5}},
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, Target: "example.com", ALPN: []string{"h2"}, ECH: []byte("xyz"),
@@ -247,6 +258,7 @@ func TestResolveResultTargets(t *testing.T) {
 		},
 		{
 			result: ResolveResult{
+				Port: 443,
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, ALPN: []string{"h2"}, IPv4Hint: []net.IP{{192, 168, 0, 1}}, ECH: []byte("xyz"),
 				}},
@@ -255,6 +267,7 @@ func TestResolveResultTargets(t *testing.T) {
 		},
 		{
 			result: ResolveResult{
+				Port: 443,
 				HTTPS: []dns.HTTPS{{
 					Priority: 1, Target: "foo", ALPN: []string{"h2"}, Port: 8443, IPv4Hint: []net.IP{{192, 168, 0, 1}}, ECH: []byte("xyz"),
 				}},


### PR DESCRIPTION
The name argument to Resolve() can now include a :port, or it can be a fully qualified URI.

The scheme and port are used to locate the correct HTTPS RR as specified in RFC 9460 section 2.3.